### PR TITLE
Moving rightside NUM modifier chord from RR|RB to RB|RG to match diag…

### DIFF
--- a/keyboards/butterstick/keymaps/default/keymap.c
+++ b/keyboards/butterstick/keymaps/default/keymap.c
@@ -16,7 +16,7 @@
 #define MOVE	(LSU | LFT | LP | LH)	
 #define SYMB	(RD  | RZ)	
 #define NUMA    (LW  | LR)	
-#define NUMB    (RR  | RB)	
+#define NUMB    (RB  | RG)
 
 // QMK Layer Numbers
  #define BASE 0


### PR DESCRIPTION
Diagrams show the right hand numbers modifier 'NUMB' on the RB|RG chord, while the default keymap places it at RR|RB. This is a one-line change to move the 'NUMB' chord to the documented (and symmetric) location.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
