### PR TITLE
Minor changes to dictionary switching mechanism

### DIFF
--- a/keyboards/gboards/g/engine.c
+++ b/keyboards/gboards/g/engine.c
@@ -52,6 +52,9 @@ uint16_t repTimer   = 0;
 bool   inMouse = false;
 int8_t mousePress;
 
+//Dictionary Check 
+uint16_t oldStick=0;
+
 // All processing done at chordUp goes through here
 void processKeysUp() {
     // Check for mousekeys, this is release
@@ -404,7 +407,20 @@ void REPEAT(void) {
     return;
 }
 void SET_STICKY(C_SIZE stick) {
-    stickyBits ^= stick;
+   if (stickyBits==0){
+				stickyBits ^= stick; // if stickyBits is ALREADY zero then 0 gets passed thru as its either needed or its a zero sent by something deeper within QMK
+				} 
+			else if(stick > 0 && oldStick==stick) { //arg is more than 0 and its the same as before so back to layer 0: NUM->NUM->0
+				stickyBits = 0; 
+				}	
+			else if(stick > 0 && oldStick!=stick)  {// arg is more than 0 and not the same so reset the stickyBits and increment away: NUM->CMD->NUM
+				stickyBits ^= oldStick;
+				stickyBits ^= stick;
+				}	
+			else {
+				stickyBits = 0; // Failsafe back to 0
+				}
+			oldStick = stick;  //record the dictionary we have now set for the next dictionary switch 
     return;
 }
 void CLICK_MOUSE(uint8_t kc) {


### PR DESCRIPTION
Humble PR (and firsty on GH) for ginny keyboard to try and enable dictionary switching with a dictionary reset on failsafe.
Will update as I try the keyboard a bit more. Apologies for any code formatting errors.

Still struggling to get eyes onto what happens with that first if statement, but I think it is correctly formed to receive the SET_STICKY(0) arguments when sent.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* https://github.com/qmk-combos/combos/issues/5

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
