### PR TITLE
Change layer_on to layer_move

### DIFF
--- a/keyboards/georgi/sten.c
+++ b/keyboards/georgi/sten.c
@@ -98,7 +98,7 @@ bool send_steno_chord_user(steno_mode_t mode, uint8_t chord[6]) {
 #ifndef NO_DEBUG
 		uprintf("Switching to QMK\n");
 #endif
-		layer_on(1);
+		layer_move(1);
 		goto out;
 	}
 


### PR DESCRIPTION
I think layer_move makes more sense here, because the layer 1 overrides layer 0 completely anyway.

(and it prevents some annoying debugging-time if someone decide to move layer GAMING to a smaller index than layer STENO_LAYER)

Note. (the issues tab is not open? And) I'm not sure which branch to push to.

----

Also on that note, I'd like to move the macro definitions to some header file and use from that header file too (but that might potentially be disruptive), hard coding `1` there isn't a good idea.

----

... in retrospect, it might be better to just add `layer_move(GAMING)` to the startup script to make that layer the default from the beginning. Had some unrelated issues with EEPROM and `set_single_persistent_default_layer`.